### PR TITLE
Update mongojs dependency

### DIFF
--- a/app/coffee/mongojs.coffee
+++ b/app/coffee/mongojs.coffee
@@ -1,6 +1,6 @@
 Settings = require "settings-sharelatex"
 mongojs = require "mongojs"
-db = mongojs.connect(Settings.mongo.url, ["contacts"])
+db = mongojs(Settings.mongo.url, ["contacts"])
 module.exports =
 	db: db
 	ObjectId: mongojs.ObjectId

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
-    "mongojs": "0.18.2",
+    "mongojs": "2.4.0",
     "express": "~4.1.1",
     "underscore": "~1.6.0",
     "body-parser": "~1.0.2",


### PR DESCRIPTION
to be in line with the other subprojects.

The old mongojs fails to run with
"TypeError: Proxy.create is not a function"