### PR TITLE
 Provide hosts as environment settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -5,7 +5,7 @@ module.exports =
 	internal:
 		contacts:
 			port: 3036
-			host: "localhost"
+			host: process.env["LISTEN_ADDRESS"] or "localhost"
 
 	mongo:
-		url: 'mongodb://127.0.0.1/sharelatex'
+		url: "mongodb://#{process.env["MONGO_HOST"] or "localhost"}/sharelatex"

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
     "start": "npm run compile:app && node app.js"
   },
   "dependencies": {
-    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+    "async": "~0.8.0",
+    "body-parser": "~1.0.2",
+    "coffee-script": "^1.7.1",
+    "express": "~4.1.1",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
     "mongojs": "0.18.2",
-    "express": "~4.1.1",
-    "underscore": "~1.6.0",
-    "body-parser": "~1.0.2",
-    "async": "~0.8.0",
-    "request": "~2.34.0"
+    "request": "~2.34.0",
+    "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/sharelatex/contacts-sharelatex.git"
   },
+  "scripts": {
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
+  },
   "dependencies": {
     "settings-sharelatex": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.