### PR TITLE
[GettingContactsTests] add missing done argument

### DIFF
--- a/test/acceptance/coffee/GettingContactsTests.coffee
+++ b/test/acceptance/coffee/GettingContactsTests.coffee
@@ -59,7 +59,7 @@ describe "Getting Contacts", ->
 				body.contact_ids.should.deep.equal [@contact_id_2, @contact_id_3, @contact_id_1]
 				done()
 		
-		it "should respect a limit and only return top X contacts", ->
+		it "should respect a limit and only return top X contacts", (done) ->
 			request {
 				method: "GET"
 				url: "#{HOST}/user/#{@user_id}/contacts?limit=2"


### PR DESCRIPTION
### Description
One of the async acceptance tests is missing the `done` argument in the definition of the test function.

The http request is in general too slow to complete, before mocha triggers the process exit, so this patch is not urgent in any way.

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
